### PR TITLE
Add support for optional host header to support Virtual Hosts in RabbitMQ

### DIFF
--- a/stomp.rpgle
+++ b/stomp.rpgle
@@ -220,6 +220,22 @@ dcl-proc stomp_setTimeout export;
 end-proc;
 
 
+dcl-proc stomp_setVirtualHost export;
+  dcl-pi *N;
+    conn pointer const;
+    pVirtualHost varchar(100) const;
+  end-pi;
+  
+  dcl-ds header likeds(stomp_header_t) based(conn);
+  dcl-s virtualHost varchar(100);
+
+  virtualHost = pVirtualHost;
+  tree_rb_int_put(header.options : STOMP_OPTION_VIRTUAL_HOST :
+                  %addr(virtualHost : *DATA) : %len(virtualHost));
+  Logger_debug(logger : 'set client id: ' + pVirtualHost);
+end-proc;
+
+
 dcl-proc stomp_setClientId export;
   dcl-pi *N;
     conn pointer const;

--- a/stomp_h.rpgle
+++ b/stomp_h.rpgle
@@ -416,6 +416,7 @@ dcl-s stomp_receiptid_t varchar(50) template;
 dcl-c STOMP_ACK_MODE_AUTO 'auto';
 dcl-c STOMP_ACK_MODE_CLIENT 'client';
 dcl-c STOMP_OPTION_TIMEOUT 1;
+dcl-c STOMP_OPTION_VIRTUAL_HOST 'host';
 dcl-c STOMP_OPTION_CLIENT_ID 2;
 dcl-c STOMP_OPTION_ACK 3;
 dcl-c STOMP_OPTION_PERSISTENT 4;

--- a/stompcmd.rpgle
+++ b/stompcmd.rpgle
@@ -87,6 +87,11 @@ dcl-proc stomp_command_connect export;
     stomp_frame_setHeader(frame : 'client-id' :  %str(optionPtr));
   endif;
   
+  if (stomp_hasOption(conn : STOMP_OPTION_VIRTUAL_HOST));
+    optionPtr = stomp_getOptionValue(conn : STOMP_OPTION_VIRTUAL_HOST);
+    stomp_frame_setHeader(frame : 'host' : %str(optionPtr));
+  endif;
+  
   if (stomp_getExtension(conn) <> *null);
     stomp_ext_connect(stomp_getExtension(conn) : conn : frame : user:pass);
   endif;


### PR DESCRIPTION
Virtual Hosts are not technically supported until STOMP 1.1, but RabbitMQ will take the optional host header to handle virtual hosts even if the negotiated protocol is STOMP 1.0.